### PR TITLE
Worker pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## UNRELEASED
+
+* [#3](https://github.com/kukushkin/mimi-messaging-sqs_sns/pull/3)
+  * Added a worker pool:
+    * now processing of messages from a single queue can be done in multiple parallel threads (workers)
+    * the worker threads are shared across all message consumers which read messages from different queues
+    * the size of the worker pool is limited, to have at most `mq_worker_pool_max_threads` processing messages in parallel
+    * `mq_worker_pool_min_threads` determines the target minimal number of threads in the pool, waiting for new messages
+    * `mq_worker_pool_max_backlog` controls how many messages which are read from SQS queues can be put in the worker pool backlog; if a new message is read from SQS queue and the backlog is full, this message is NACK-ed (put back into SQS queue for the other consumers to process)
+  * Improved thread-safety of the adapter: reply consumer, TimeoutQueue#pop
+
 ## v0.7.0
 
 * [#1](https://github.com/kukushkin/mimi-messaging-sqs_sns/pull/1)

--- a/examples/event.rb
+++ b/examples/event.rb
@@ -4,8 +4,8 @@ require "mimi/messaging/sqs_sns"
 
 COUNT = 10
 AWS_REGION            = "eu-west-1"
-AWS_SQS_ENDPOINT_URL  = "http://localstack:4576"
-AWS_SNS_ENDPOINT_URL  = "http://localstack:4575"
+AWS_SQS_ENDPOINT_URL  = "http://localstack:4566"
+AWS_SNS_ENDPOINT_URL  = "http://localstack:4566"
 AWS_ACCESS_KEY_ID     = "foo"
 AWS_SECRET_ACCESS_KEY = "bar"
 
@@ -30,5 +30,5 @@ COUNT.times do |i|
   t = Time.now
   puts "Publishing event: #{i}"
   adapter.event("hello#tested", i: i) # rand(100))
-  sleep 1
+  sleep 0.1
 end

--- a/examples/subscriber.rb
+++ b/examples/subscriber.rb
@@ -3,8 +3,8 @@
 require "mimi/messaging/sqs_sns"
 
 AWS_REGION = "eu-west-1"
-AWS_SQS_ENDPOINT_URL = "http://localstack:4576"
-AWS_SNS_ENDPOINT_URL = "http://localstack:4575"
+AWS_SQS_ENDPOINT_URL  = "http://localstack:4566"
+AWS_SNS_ENDPOINT_URL  = "http://localstack:4566"
 AWS_ACCESS_KEY_ID = "foo"
 AWS_SECRET_ACCESS_KEY = "bar"
 
@@ -20,6 +20,7 @@ class Processor
 
   def self.call_event(event_type, message, opts)
     puts "EVENT: #{event_type}, #{message}, headers: #{message.headers}"
+    sleep 1 # imitate work
   end
 end # class Processor
 
@@ -34,6 +35,9 @@ Mimi::Messaging.configure(
   mq_aws_region:            AWS_REGION,
   mq_aws_sqs_endpoint:      AWS_SQS_ENDPOINT_URL,
   mq_aws_sns_endpoint:      AWS_SNS_ENDPOINT_URL,
+  mq_worker_pool_min_threads: 1,
+  mq_worker_pool_max_threads: 2,
+  mq_worker_pool_max_backlog: 4,
   mq_log_at_level: :info
 )
 adapter = Mimi::Messaging.adapter
@@ -52,4 +56,3 @@ ensure
   puts "Stopping adapter"
   adapter.stop
 end
-

--- a/lib/mimi/messaging/sqs_sns/reply_consumer.rb
+++ b/lib/mimi/messaging/sqs_sns/reply_consumer.rb
@@ -36,7 +36,7 @@ module Mimi
         # @return [Queue] a new Queue object registered for this request_id
         #
         def register_request_id(request_id)
-          queue = Queue.new
+          queue = TimeoutQueue.new
           @mutex.synchronize do
             queue = @queues[request_id] ||= queue
           end

--- a/lib/mimi/messaging/sqs_sns/timeout_queue.rb
+++ b/lib/mimi/messaging/sqs_sns/timeout_queue.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "timeout"
+
+module Mimi
+  module Messaging
+    module SQS_SNS
+      # TimeoutQueue solves the problem the native Ruby Queue class has with waiting for elements.
+      #
+      # See the excellent blog post discussing the issue:
+      # https://medium.com/workday-engineering/ruby-concurrency-building-a-timeout-queue-5d7c588ca80d
+      #
+      # TLDR -- using Ruby standard Timeout.timeout() around Queue#pop() is unsafe
+      #
+      #
+      class TimeoutQueue
+        def initialize
+          @elems = []
+          @mutex = Mutex.new
+          @cond_var = ConditionVariable.new
+        end
+
+        # Pushes an element into the queue
+        #
+        # @param elem [Object]
+        #
+        def <<(elem)
+          @mutex.synchronize do
+            @elems << elem
+            @cond_var.signal
+          end
+        end
+        alias push <<
+
+        # Pops an element from the queue in either non-blocking
+        # or a blocking (with an optional timeout) way.
+        #
+        # @param blocking [true,false] wait for a new element (true) or return immediately
+        # @param timeout [nil,Integer] if in blocking mode,
+        #                              wait at most given number of seconds or forever (nil)
+        # @raise [Timeout::Error] if a timeout in blocking mode was reached
+        #
+        def pop(blocking = true, timeout = nil)
+          @mutex.synchronize do
+            if blocking
+              if timeout.nil?
+                while @elems.empty?
+                  @cond_var.wait(@mutex)
+                end
+              else
+                timeout_time = Time.now.to_f + timeout
+                while @elems.empty? && (remaining_time = timeout_time - Time.now.to_f) > 0
+                  @cond_var.wait(@mutex, remaining_time)
+                end
+              end
+            end
+            raise Timeout::Error, "queue timeout expired" if @elems.empty?
+
+            @elems.shift
+          end
+        end
+      end # class TimeoutQueue
+    end # module SQS_SNS
+  end # module Messaging
+end # module Mimi

--- a/mimi-messaging-sqs_sns.gemspec
+++ b/mimi-messaging-sqs_sns.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "mimi-messaging", "~> 1.2"
   spec.add_dependency "aws-sdk-sqs", "~> 1.22"
   spec.add_dependency "aws-sdk-sns", "~> 1.19"
+  spec.add_dependency "concurrent-ruby"
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "pry", "~> 0.12"


### PR DESCRIPTION
* Added a worker pool:
  * now processing of messages from a single queue can be done in multiple parallel threads (workers)
  * the worker threads are shared across all message consumers which read messages from different queues 
  * the size of the worker pool is limited, to have at most `mq_worker_pool_max_threads` processing messages in parallel
  * `mq_worker_pool_min_threads` determines the target minimal number of threads in the pool, waiting for new messages
  * `mq_worker_pool_max_backlog` controls how many messages which are read from SQS queues can be put in the worker pool backlog; if a new message is read from SQS queue and the backlog is full, this message is NACK-ed (put back into SQS queue for the other consumers to process)
* Improved thread-safety of the adapter: reply consumer, TimeoutQueue#pop  